### PR TITLE
Add screenshot section on home page

### DIFF
--- a/zenofideas/src/app/app.component.html
+++ b/zenofideas/src/app/app.component.html
@@ -1,5 +1,6 @@
 <app-navbar></app-navbar>
 <app-hero></app-hero>
+<app-screenshots></app-screenshots>
 <app-about></app-about>
 <app-product></app-product>
 <app-gallery></app-gallery>

--- a/zenofideas/src/app/app.module.ts
+++ b/zenofideas/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { RandomPoseComponent } from './components/random-pose/random-pose.compon
 import { GalleryComponent } from './components/gallery/gallery.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { FooterComponent } from './components/footer/footer.component';
+import { ScreenshotsComponent } from './components/screenshots/screenshots.component';
 import { RevealDirective } from './directives/reveal.directive';
 
 @NgModule({
@@ -27,6 +28,7 @@ import { RevealDirective } from './directives/reveal.directive';
     GalleryComponent,
     ContactComponent,
     FooterComponent,
+    ScreenshotsComponent,
     RevealDirective
   ],
   imports: [

--- a/zenofideas/src/app/components/screenshots/screenshots.component.ts
+++ b/zenofideas/src/app/components/screenshots/screenshots.component.ts
@@ -1,0 +1,58 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-screenshots',
+  template: `
+    <section id="screenshots" class="screenshots" appReveal>
+      <div class="shot" *ngFor="let s of shots">
+        <img [src]="s.image" [alt]="s.title" />
+        <h3>{{ s.title }}</h3>
+        <p>{{ s.description }}</p>
+      </div>
+    </section>
+  `,
+  styles: [
+    `
+      .screenshots {
+        padding: 4rem 2rem;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 2rem;
+        background: #fff;
+        text-align: center;
+      }
+      .shot img {
+        width: 100%;
+        max-width: 200px;
+        margin: 0 auto;
+        display: block;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+      }
+    `
+  ]
+})
+export class ScreenshotsComponent {
+  shots = [
+    {
+      image: 'https://via.placeholder.com/200x400?text=Screen+1',
+      title: 'Home Screen',
+      description: 'Overview of recent projects and updates.'
+    },
+    {
+      image: 'https://via.placeholder.com/200x400?text=Screen+2',
+      title: 'Gallery View',
+      description: 'Browse your images in an easy grid.'
+    },
+    {
+      image: 'https://via.placeholder.com/200x400?text=Screen+3',
+      title: 'Pose Suggestions',
+      description: 'Get recommended poses tailored to your needs.'
+    },
+    {
+      image: 'https://via.placeholder.com/200x400?text=Screen+4',
+      title: 'Profile Settings',
+      description: 'Manage your account preferences quickly.'
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- show mobile screenshot mockups on home page

## Testing
- `npm test` *(fails: Chrome not available)*

------
https://chatgpt.com/codex/tasks/task_e_68623e3512908333ba124dacf02494fa