### PR TITLE
Fix CORS issue for trending API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "workspace-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^2.6.7"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const app = express();
+const PORT = process.env.PORT || 3000;
+const API_URL = 'https://posedirector-service-601906407780.us-west4.run.app';
+
+app.use('/api/random-pose', async (req, res) => {
+  try {
+    const response = await fetch(`${API_URL}/random-pose`);
+    const data = await response.json();
+    res.set('Access-Control-Allow-Origin', '*');
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch random pose' });
+  }
+});
+
+app.use('/api/trending', async (req, res) => {
+  try {
+    const { seed = 100, start = 0, limit = 10 } = req.query;
+    const url = `${API_URL}/trending?seed=${seed}&start=${start}&limit=${limit}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    res.set('Access-Control-Allow-Origin', '*');
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch trending images' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/zenofideas/src/app/services/trending.service.ts
+++ b/zenofideas/src/app/services/trending.service.ts
@@ -9,7 +9,10 @@ export interface TrendingImage {
 
 @Injectable({ providedIn: 'root' })
 export class TrendingService {
-  private api = 'https://posedirector-service-601906407780.us-west4.run.app';
+  // Point to the local API proxy to avoid CORS issues when requesting the
+  // trending endpoint. The proxy server forwards requests to the actual
+  // posedirector service and adds the necessary CORS headers.
+  private api = '/api';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- add a simple Express proxy server for API requests
- change the trending service to use the local `/api` proxy
- ignore node modules and lock file at repo root

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623b7b23008333904b2d526e741b7b